### PR TITLE
Remove the warning about outdated debian packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ In order to install Browserpass correctly, you have to install two of its compon
 -   Browser extension for Chromium-based browsers (choose one of the options):
     -   Install using a package manager for your OS (which will provide auto-update and keep extension in sync with native host app):
         -   Arch Linux: [browserpass-chromium](https://www.archlinux.org/packages/community/any/browserpass-chromium/), [browserpass-chrome](https://aur.archlinux.org/packages/browserpass-chrome/)
-        -   Debian: [webext-browserpass](https://packages.debian.org/sid/webext-browserpass) includes Chromium extension (**DO NOT USE, it's significantly outdated**)
+        -   Debian: [webext-browserpass](https://packages.debian.org/stable/webext-browserpass) includes Chromium extension
     -   Install the extension from [Chrome Web Store](https://chrome.google.com/webstore/detail/browserpass-ce/naepdomgkenhinolocfifgehidddafch) (which will provide auto-updates)
     -   Download `browserpass-webstore.crx` from the latest release and drag'n'drop it into `chrome://extensions`
         -   This extension has the same ID as the one in Chrome Web Store, so when a new version will appear in Web Store, it will auto-update! Use if you want to be on latest and greatest version.
@@ -63,7 +63,7 @@ In order to install Browserpass correctly, you have to install two of its compon
 -   Browser extension for Firefox-based browsers (choose one of the options):
     -   Install using a package manager for your OS (which will provide auto-update and keep extension in sync with native host app):
         -   Arch Linux: [browserpass-firefox](https://www.archlinux.org/packages/community/any/browserpass-firefox/)
-        -   Debian: [webext-browserpass](https://packages.debian.org/sid/webext-browserpass) includes Firefox extension (**DO NOT USE, it's significantly outdated**)
+        -   Debian: [webext-browserpass](https://packages.debian.org/stable/webext-browserpass) includes Firefox extension
     -   Install the extension from [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/browserpass-ce/) (which will provide auto-updates)
     -   Download `browserpass-firefox.zip` from the latest release, unarchive and use `Load Temporary Add-on` on `about:debugging#addons` (remember the extension will be removed after browser is closed!).
 


### PR DESCRIPTION
Debian has version 3.7.2 imported to stable, so it's pretty up to date now.
This also changes the links to point to debian stable.